### PR TITLE
reimplement require("text!file")

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ var through = require('through');
 var falafel = require('falafel');
 var fs = require('fs');
 
+var prefix = /^text!/;
+
 function create(config) {
 	return function(file) {
 		var source = '';
@@ -28,8 +30,16 @@ function create(config) {
 			return String(falafel(source, { locations: true, ecmaVersion: 6 }, function(node) {
 
 				// Find require() calls
-				if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === 'requireText') {
-					var requirePath = node.arguments[0].value;
+				if (node.type === 'CallExpression' && node.callee.type === 'Identifier') {
+					var requirePath;
+
+					if(node.callee.name === 'requireText') { // requireText("file.txt")
+						requirePath = node.arguments[0].value;
+					} else if(node.callee.name === 'require' && prefix.test(node.arguments[0].value)) { // require("text!file.txt")
+						requirePath = node.arguments[0].value.replace(prefix, '');
+					} else {// none of the above, skip
+						return;
+					}
 
 					var fsPath;
 					if (/^\.+\//.test(requirePath)) {

--- a/test/compiletargetbang.js
+++ b/test/compiletargetbang.js
@@ -1,0 +1,1 @@
+var test = require('text!./textfile.txt');

--- a/test/es6compiletargetbang.js
+++ b/test/es6compiletargetbang.js
@@ -1,0 +1,1 @@
+let test = require("text!textfile.txt");

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,21 @@ it('should include file as an inline string', function(done) {
 	});
 });
 
+it('should include file as an inline string with webpack loader syntax', function(done) {
+	var b = browserify();
+	b.add(path.join(__dirname, 'compiletargetbang.js'));
+	b.transform(textrequireify.create({ rootDirectory: __dirname }));
+	b.bundle(function(e, buffer) {
+		if (e) {
+			done(e);
+			return;
+		}
+
+		assert(buffer.toString().indexOf('testcontent') >= 0);
+		done();
+	});
+});
+
 it('should work with es6 files', function(done) {
 	var b = browserify();
 	b.add(path.join(__dirname, 'es6compiletarget.js'));
@@ -32,4 +47,19 @@ it('should work with es6 files', function(done) {
 		assert(buffer.toString().indexOf('testcontent') >= 0);
 		done();
 	});
+});
+
+it('should work with es6 files and require loader syntax', function(done) {
+var b = browserify();
+b.add(path.join(__dirname, 'es6compiletargetbang.js'));
+b.transform(textrequireify.create({ rootDirectory: __dirname }));
+b.bundle(function(e, buffer) {
+	if (e) {
+		done(e);
+		return;
+	}
+
+	assert(buffer.toString().indexOf('testcontent') >= 0);
+	done();
+});
 });


### PR DESCRIPTION
Keeps `requireText("file")` support intact