### PR TITLE
resolve rootdirectory to make relative check more robust

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function create(config) {
 		var source = '';
 		if (!(/\.js$/).test(file)) return through();
 
-		var rootDirectory = path.normalize(config.rootDirectory || './bower_components/');
+		var rootDirectory = path.resolve(path.normalize(config.rootDirectory || './bower_components/'));
 
 		var tr = through(function(buf){source += buf;}, function(){
 			try {


### PR DESCRIPTION
The check on [line 51](https://github.com/ftlabs/textrequireify/blob/master/index.js#L51) assumes `rootDirectory` is absolute, which it isn't always.
